### PR TITLE
Adapt implementation from lace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This library is optimized for cloud computation, however it depends on both
 [NumPy][] and [the SciPy k-d tree][ckdtree]. It's designed for use with
 [lacecore][].
 
+Currently works only with triangular meshes.
+
 Prior to version 1.0, this was a library for rendering mesh cross sections to
 SVG. That library has been renamed to [hobart-svg][].
 

--- a/hobart/__init__.py
+++ b/hobart/__init__.py
@@ -1,1 +1,5 @@
+from . import _core
+from ._core import *  # noqa: F403,F401
 from .package_version import __version__  # noqa: F401
+
+__all__ = _core.__all__

--- a/hobart/_core.py
+++ b/hobart/_core.py
@@ -1,0 +1,160 @@
+# Adapted from
+# https://github.com/lace/lace/blob/a19d14eeca37a66af442c5a73c3934987d2d7d9a/lace/intersection.py
+# https://github.com/lace/lace/blob/a19d14eeca37a66af442c5a73c3934987d2d7d9a/lace/test_intersection.py
+# By Body Labs & Metabolize, BSD License
+
+import numpy as np
+from polliwog import Polyline
+import vg
+from ._internal import EdgeMap, Graph
+from ._validation import check_indices
+
+
+def faces_intersecting_plane(vertices, faces, plane):
+    """
+    Efficiently compute which of the given faces intersect the given plane.
+
+    Args:
+        vertices (np.ndarray): The vertices, as a `nx3` array.
+        faces (np.ndarray): The face indices, as a `kx3` array.
+        plane (polliwog.Plane): The plane of interest.
+
+    Returns:
+        np.ndarray: A boolean mask indicating the faces which intersect
+            the given plane.
+    """
+    vg.shape.check(locals(), "vertices", (-1, 3))
+    vg.shape.check(locals(), "faces", (-1, 3))
+    check_indices(faces, len(vertices), "faces")
+
+    signed_distances = plane.signed_distance(vertices)
+    return np.abs(np.sign(signed_distances)[faces].sum(axis=1)) != 3
+
+
+def intersect_mesh_with_plane(
+    vertices, faces, plane, neighborhood=None, ret_pointcloud=False
+):
+    """
+    Takes a cross section of planar point cloud with a Mesh object.
+    Ignore those points which intersect at a vertex - the probability of
+    this event is small, and accounting for it complicates the algorithm.
+
+    When a plane may intersect the mesh more than once, provide a
+    `neighborhood`, which is a set of points. The cross section closest
+    to this list of points is returned (using a kd-tree).
+
+    Args:
+        vertices (np.ndarray): The vertices, as a `nx3` array.
+        faces (np.ndarray): The face indices, as a `kx3` array.
+        plane (polliwog.Plane): The plane of interest.
+        neighborhood (np.ndarray): One or more points of interest, used to
+            select the desired cross section when a plane may intersect more
+            than once.
+        ret_pointcloud (bool): When `True`, return an unstructured point
+            cloud instead of a list of polylines. This is useful when
+            you aren't specifying a neighborhood and you only care about
+            e.g. some apex of the intersection.
+
+    Returns:
+        list: A list of `polliwog.Polyline` instances.
+
+    See also:
+        https://polliwog.readthedocs.io/en/latest/#polliwog.Polyline
+    """
+    if neighborhood is not None:
+        vg.shape.check(locals(), "neighborhood", (-1, 3))
+
+    # 1: Select those faces that intersect the plane, fs
+    fs = faces[faces_intersecting_plane(vertices, faces, plane)]
+
+    if len(fs) == 0:
+        # Nothing intersects.
+        if ret_pointcloud:
+            return np.zeros((0, 3))
+        elif neighborhood is not None:
+            return None
+        else:
+            return []
+
+    # and edges of those faces
+    es = np.vstack((fs[:, (0, 1)], fs[:, (1, 2)], fs[:, (2, 0)]))
+
+    # 2: Find the edges where each of those faces actually cross the plane
+    intersection_map = EdgeMap()
+
+    pts, pt_is_valid = plane.line_segment_xsections(
+        vertices[es[:, 0]], vertices[es[:, 1]]
+    )
+    valid_pts = pts[pt_is_valid]
+    valid_es = es[pt_is_valid]
+    for val, e in zip(valid_pts, valid_es):
+        if not intersection_map.contains(e[0], e[1]):
+            intersection_map.add(e[0], e[1], val)
+    verts = np.array(intersection_map.values)
+
+    # 3: Build the edge adjacency graph
+    G = Graph(verts.shape[0])
+    for f in fs:
+        # Since we're dealing with a triangle that intersects the plane,
+        # exactly two of the edges will intersect (note that the only other
+        # sorts of "intersections" are one edge in plane or all three edges in
+        # plane, which won't be picked up by mesh_intersecting_faces).
+        e0 = intersection_map.index(f[0], f[1])
+        e1 = intersection_map.index(f[0], f[2])
+        e2 = intersection_map.index(f[1], f[2])
+        if e0 is None:
+            G.add_edge(e1, e2)
+        elif e1 is None:
+            G.add_edge(e0, e2)
+        else:
+            G.add_edge(e0, e1)
+
+    # 4: Find the paths for each component
+    components = []
+    components_closed = []
+    while len(G) > 0:
+        path = G.pop_euler_path()
+        if path is None:
+            raise ValueError(
+                "Mesh slice has too many odd degree edges; can't find a path along the edge"
+            )
+        component_verts = verts[path]
+
+        if np.all(component_verts[0] == component_verts[-1]):
+            # Because the closed polyline will make that last link:
+            component_verts = np.delete(component_verts, 0, axis=0)
+            components_closed.append(True)
+        else:
+            components_closed.append(False)
+        components.append(component_verts)
+
+    # 6 (optional - only if 'neighborhood' is provided): Use a KDTree to select
+    # the component with minimal distance to 'neighborhood'.
+    if neighborhood is not None and len(components) > 1:
+        from scipy.spatial import cKDTree
+
+        kdtree = cKDTree(neighborhood)
+
+        # The number of components will not be large in practice, so this loop
+        # won't hurt.
+        means = [np.mean(kdtree.query(component)[0]) for component in components]
+        index = np.argmin(means)
+        if ret_pointcloud:
+            return components[index]
+        else:
+            return Polyline(components[index], is_closed=components_closed[index])
+    elif neighborhood is not None and len(components) == 1:
+        if ret_pointcloud:
+            return components[0]
+        else:
+            return Polyline(components[0], is_closed=components_closed[0])
+    else:
+        # No neighborhood provided, so return all the components, either in a
+        # pointcloud or as separate polylines.
+        if ret_pointcloud:
+            return np.vstack(components)
+        else:
+            return [
+                Polyline(v, is_closed=closed)
+                for v, closed in zip(components, components_closed)
+            ]

--- a/hobart/_core.py
+++ b/hobart/_core.py
@@ -10,10 +10,7 @@ import vg
 from ._internal import EdgeMap, Graph
 from ._validation import check_indices
 
-__all__ = [
-    "faces_intersecting_plane",
-    "intersect_mesh_with_plane",
-]
+__all__ = ["faces_intersecting_plane", "intersect_mesh_with_plane"]
 
 
 def faces_intersecting_plane(vertices, faces, plane):
@@ -117,7 +114,7 @@ def intersect_mesh_with_plane(
         elif e1 is None:
             G.add_edge(e0, e2)
         else:
-            G.add_edge(e0, e1)
+            G.add_edge(e0, e1)  # pragma: no cover
 
     # 4: Find the paths for each component
     components = []
@@ -125,7 +122,7 @@ def intersect_mesh_with_plane(
     while len(G) > 0:
         path = G.pop_euler_path()
         if path is None:
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 "Mesh slice has too many odd degree edges; can't find a path along the edge"
             )
         component_verts = verts[path]
@@ -152,10 +149,12 @@ def intersect_mesh_with_plane(
         else:
             return Polyline(components[index], is_closed=components_closed[index])
     elif neighborhood is not None and len(components) == 1:
-        if ret_pointcloud:
-            return components[0]
+        if ret_pointcloud:  # pragma: no cover
+            return components[0]  # pragma: no cover
         else:
-            return Polyline(components[0], is_closed=components_closed[0])
+            return Polyline(
+                components[0], is_closed=components_closed[0]
+            )  # pragma: no cover
     else:
         # No neighborhood provided, so return all the components, either in a
         # pointcloud or as separate polylines.

--- a/hobart/_core.py
+++ b/hobart/_core.py
@@ -10,6 +10,11 @@ import vg
 from ._internal import EdgeMap, Graph
 from ._validation import check_indices
 
+__all__ = [
+    "faces_intersecting_plane",
+    "intersect_mesh_with_plane",
+]
+
 
 def faces_intersecting_plane(vertices, faces, plane):
     """
@@ -23,6 +28,9 @@ def faces_intersecting_plane(vertices, faces, plane):
     Returns:
         np.ndarray: A boolean mask indicating the faces which intersect
             the given plane.
+
+    See also:
+        https://polliwog.readthedocs.io/en/latest/#polliwog.Plane
     """
     vg.shape.check(locals(), "vertices", (-1, 3))
     vg.shape.check(locals(), "faces", (-1, 3))
@@ -60,6 +68,7 @@ def intersect_mesh_with_plane(
         list: A list of `polliwog.Polyline` instances.
 
     See also:
+        https://polliwog.readthedocs.io/en/latest/#polliwog.Plane
         https://polliwog.readthedocs.io/en/latest/#polliwog.Polyline
     """
     if neighborhood is not None:

--- a/hobart/_core.py
+++ b/hobart/_core.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from polliwog import Polyline
+from scipy.spatial import cKDTree
 import vg
 from ._internal import EdgeMap, Graph
 from ._validation import check_indices
@@ -131,13 +132,11 @@ def intersect_mesh_with_plane(
     # 6 (optional - only if 'neighborhood' is provided): Use a KDTree to select
     # the component with minimal distance to 'neighborhood'.
     if neighborhood is not None and len(components) > 1:
-        from scipy.spatial import cKDTree
-
-        kdtree = cKDTree(neighborhood)
+        tree = cKDTree(neighborhood)
 
         # The number of components will not be large in practice, so this loop
         # won't hurt.
-        means = [np.mean(kdtree.query(component)[0]) for component in components]
+        means = [np.mean(tree.query(component)[0]) for component in components]
         index = np.argmin(means)
         if ret_pointcloud:
             return components[index]

--- a/hobart/_internal.py
+++ b/hobart/_internal.py
@@ -5,9 +5,9 @@ class EdgeMap:
     """
 
     def __init__(self):
-        self.d = (
-            {}
-        )  # store indicies into self.values here, to make it easier to get inds or values
+        # Store indicies into self.values here, to make it easier to get inds
+        # or values.
+        self.d = {}
         self.values = []
 
     def _order(self, u, v):
@@ -75,14 +75,15 @@ class Graph:
         # Under PSF License
         # NB: MUTATES d
 
-        # counting the number of vertices with odd degree
+        # Count the number of vertices with odd degree.
         odd = [x for x in self.d if len(self.d[x]) & 1]
         odd.append(list(self.d.keys())[0])
         if not allow_multiple_connected_components and len(odd) > 3:
             return None
         stack = [odd[0]]
         path = []
-        # main algorithm
+
+        # Main algorithm.
         while stack:
             v = stack[-1]
             if v in self.d:

--- a/hobart/_internal.py
+++ b/hobart/_internal.py
@@ -1,0 +1,105 @@
+class EdgeMap:
+    """
+    A quick two-level dictionary where the two keys are interchangeable (i.e.
+    a symmetric graph).
+    """
+
+    def __init__(self):
+        self.d = (
+            {}
+        )  # store indicies into self.values here, to make it easier to get inds or values
+        self.values = []
+
+    def _order(self, u, v):
+        if u < v:
+            return u, v
+        else:
+            return v, u
+
+    def add(self, u, v, val):
+        low, high = self._order(u, v)
+        if low not in self.d:
+            self.d[low] = {}
+        self.values.append(val)
+        self.d[low][high] = len(self.values) - 1
+
+    def contains(self, u, v):
+        low, high = self._order(u, v)
+        if low in self.d and high in self.d[low]:
+            return True
+        return False
+
+    def index(self, u, v):
+        low, high = self._order(u, v)
+        try:
+            return self.d[low][high]
+        except KeyError:
+            return None
+
+    def get(self, u, v):
+        ii = self.index(u, v)
+        if ii is not None:
+            return self.values[ii]
+        else:
+            return None
+
+
+class Graph:
+    """
+    A little utility class to build a symmetric graph and calculate Euler Paths.
+    """
+
+    def __init__(self, size):
+        self.size = size
+        self.d = {}
+
+    def __len__(self):
+        return len(self.d)
+
+    def add_edges(self, edges):
+        for u, v in edges:
+            self.add_edge(u, v)
+
+    def add_edge(self, u, v):
+        assert u >= 0 and u < self.size
+        assert v >= 0 and v < self.size
+        if u not in self.d:
+            self.d[u] = set()
+        if v not in self.d:
+            self.d[v] = set()
+        self.d[u].add(v)
+        self.d[v].add(u)
+
+    def remove_edge(self, u, v):
+        if u in self.d and v in self.d[u]:
+            self.d[u].remove(v)
+        if v in self.d and u in self.d[v]:
+            self.d[v].remove(u)
+        if v in self.d and len(self.d[v]) == 0:
+            del self.d[v]
+        if u in self.d and len(self.d[u]) == 0:
+            del self.d[u]
+
+    def pop_euler_path(self, allow_multiple_connected_components=True):
+        # Based on code from Przemek Drochomirecki, Krakow, 5 Nov 2006
+        # http://code.activestate.com/recipes/498243-finding-eulerian-path-in-undirected-graph/
+        # Under PSF License
+        # NB: MUTATES d
+
+        # counting the number of vertices with odd degree
+        odd = [x for x in self.d if len(self.d[x]) & 1]
+        odd.append(list(self.d.keys())[0])
+        if not allow_multiple_connected_components and len(odd) > 3:
+            return None
+        stack = [odd[0]]
+        path = []
+        # main algorithm
+        while stack:
+            v = stack[-1]
+            if v in self.d:
+                u = self.d[v].pop()
+                stack.append(u)
+                self.remove_edge(u, v)
+            else:
+                path.append(stack.pop())
+        return path

--- a/hobart/_internal.py
+++ b/hobart/_internal.py
@@ -36,13 +36,6 @@ class EdgeMap:
         except KeyError:
             return None
 
-    def get(self, u, v):
-        ii = self.index(u, v)
-        if ii is not None:
-            return self.values[ii]
-        else:
-            return None
-
 
 class Graph:
     """
@@ -55,10 +48,6 @@ class Graph:
 
     def __len__(self):
         return len(self.d)
-
-    def add_edges(self, edges):
-        for u, v in edges:
-            self.add_edge(u, v)
 
     def add_edge(self, u, v):
         assert u >= 0 and u < self.size

--- a/hobart/_internal.py
+++ b/hobart/_internal.py
@@ -63,7 +63,7 @@ class Graph:
         if u in self.d and v in self.d[u]:
             self.d[u].remove(v)
         if v in self.d and u in self.d[v]:
-            self.d[v].remove(u)
+            self.d[v].remove(u)  # pragma: no cover
         if v in self.d and len(self.d[v]) == 0:
             del self.d[v]
         if u in self.d and len(self.d[u]) == 0:
@@ -79,7 +79,7 @@ class Graph:
         odd = [x for x in self.d if len(self.d[x]) & 1]
         odd.append(list(self.d.keys())[0])
         if not allow_multiple_connected_components and len(odd) > 3:
-            return None
+            return None  # pragma: no cover
         stack = [odd[0]]
         path = []
 

--- a/hobart/_validation.py
+++ b/hobart/_validation.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+
+def check_indices(indices, num_elements, name):
+    # Vendored in from lacecore.
+    if np.any(indices >= num_elements):
+        raise ValueError(
+            "Expected indices in {} to be less than {}".format(name, num_elements)
+        )

--- a/hobart/test_core.py
+++ b/hobart/test_core.py
@@ -39,7 +39,7 @@ non_intersecting_plane = Plane(np.array([0.0, 5.0, 0.0]), vg.basis.y)
 def create_open_box():
     v_on_faces_to_remove = np.nonzero(box_vertices[:, 0] < 0.0)[0]
     faces_to_remove = np.all(
-        np.in1d(box_faces.ravel(), v_on_faces_to_remove).reshape((-1, 3)), axis=1,
+        np.in1d(box_faces.ravel(), v_on_faces_to_remove).reshape((-1, 3)), axis=1
     )
     return box_faces[~faces_to_remove]
 

--- a/hobart/test_core.py
+++ b/hobart/test_core.py
@@ -1,0 +1,201 @@
+import numpy as np
+from polliwog import Plane, Polyline
+import vg
+from ._core import faces_intersecting_plane, intersect_mesh_with_plane
+
+box_vertices = np.array(
+    [
+        [0.5, -0.5, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5],
+        [0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5],
+        [0.5, 0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5],
+    ]
+).T
+
+box_faces = np.array(
+    [
+        [0, 1, 2],
+        [3, 2, 1],
+        [0, 2, 4],
+        [6, 4, 2],
+        [0, 4, 1],
+        [5, 1, 4],
+        [7, 5, 6],
+        [4, 6, 5],
+        [7, 6, 3],
+        [2, 3, 6],
+        [7, 3, 5],
+        [1, 5, 3],
+    ]
+)
+
+double_box_vertices = np.vstack(
+    [box_vertices, np.array([2.0, 0.0, 0.0]) + box_vertices]
+)
+double_box_faces = np.vstack([box_faces, len(box_vertices) + box_faces])
+
+non_intersecting_plane = Plane(np.array([0.0, 5.0, 0.0]), vg.basis.y)
+
+
+def create_open_box():
+    v_on_faces_to_remove = np.nonzero(box_vertices[:, 0] < 0.0)[0]
+    faces_to_remove = np.all(
+        np.in1d(box_faces.ravel(), v_on_faces_to_remove).reshape((-1, 3)), axis=1,
+    )
+    return box_faces[~faces_to_remove]
+
+
+open_box_faces = create_open_box()
+
+double_open_box_faces = np.vstack([open_box_faces, len(box_vertices) + open_box_faces])
+
+
+def test_intersection():
+    # Verify that we're finding the correct number of faces to start with.
+    assert (
+        np.count_nonzero(faces_intersecting_plane(box_vertices, box_faces, Plane.xz))
+        == 8
+    )
+
+    xss = intersect_mesh_with_plane(box_vertices, box_faces, Plane.xz)
+    assert isinstance(xss, list)
+    assert len(xss) == 1
+
+    (xs,) = xss
+    assert xs.num_v == 8
+    assert xs.is_closed is True
+    assert xs.total_length == 4.0
+    np.testing.assert_array_equal(xs.v[:, 1], np.zeros(8))
+    for a, b in zip(xs.v[0:-1, [0, 2]], xs.v[1:, [0, 2]]):
+        # Each line changes only one coordinate, and is 0.5 long.
+        assert np.sum(a == b) == 1
+        assert np.linalg.norm(a - b) == 0.5
+
+
+def test_intersection_with_ret_pointcloud():
+    (xs,) = intersect_mesh_with_plane(box_vertices, box_faces, Plane.xz)
+    pointcloud = intersect_mesh_with_plane(
+        box_vertices, box_faces, Plane.xz, ret_pointcloud=True
+    )
+    assert isinstance(pointcloud, np.ndarray)
+    np.testing.assert_array_equal(pointcloud, xs.v)
+
+
+def test_no_intersection():
+    np.testing.assert_array_equal(
+        faces_intersecting_plane(box_vertices, box_faces, non_intersecting_plane),
+        np.zeros(12),
+    )
+    xss = intersect_mesh_with_plane(box_vertices, box_faces, non_intersecting_plane)
+    assert isinstance(xss, list)
+    assert xss == []
+
+
+# TODO: Verify that we're detecting faces that lay entirely in the plane as
+# potential intersections.
+
+
+def test_no_intersection_with_neighborhood():
+    neighborhood = np.zeros((1, 3))
+    xs = intersect_mesh_with_plane(
+        box_vertices, box_faces, non_intersecting_plane, neighborhood=neighborhood
+    )
+    assert xs is None
+
+
+def test_no_intersection_with_ret_pointcloud():
+    pointcloud = intersect_mesh_with_plane(
+        box_vertices, box_faces, non_intersecting_plane, ret_pointcloud=True
+    )
+    assert isinstance(pointcloud, np.ndarray)
+    assert pointcloud.shape == (0, 3)
+
+
+def test_intersection_wth_two_components():
+    xss = intersect_mesh_with_plane(double_box_vertices, double_box_faces, Plane.xz)
+    assert isinstance(xss, list)
+    assert len(xss) == 2
+
+    first, second = xss
+    assert first.num_v == 8
+    assert second.num_v == 8
+    assert first.is_closed is True
+    assert second.is_closed is True
+
+
+def test_intersection_wth_neighborhood():
+    neighborhood = np.zeros((1, 3))
+    xs = intersect_mesh_with_plane(
+        double_box_vertices, double_box_faces, Plane.xz, neighborhood=neighborhood
+    )
+    assert isinstance(xs, Polyline)
+    assert len(xs) == 8
+    assert xs.is_closed is True
+
+
+def test_intersection_with_neighborhood_and_ret_pointcloud():
+    neighborhood = np.zeros((1, 3))
+    xs = intersect_mesh_with_plane(
+        double_box_vertices, double_box_faces, Plane.xz, neighborhood=neighborhood
+    )
+    pointcloud = intersect_mesh_with_plane(
+        double_box_vertices,
+        double_box_faces,
+        Plane.xz,
+        neighborhood=neighborhood,
+        ret_pointcloud=True,
+    )
+    assert isinstance(pointcloud, np.ndarray)
+    np.testing.assert_array_equal(pointcloud, xs.v)
+
+
+def test_intersection_with_non_watertight_mesh():
+    xss = intersect_mesh_with_plane(box_vertices, open_box_faces, Plane.xz)
+
+    assert isinstance(xss, list)
+    assert len(xss) == 1
+
+    (xs,) = xss
+    # The removed side is not in the xsection.
+    assert not np.any(np.all(xs.v == [-0.5, 0.0, 0.0]))
+
+    assert xs.num_v == 7
+    assert xs.is_closed is False
+
+    assert xs.total_length == 3.0
+
+    np.testing.assert_array_equal(xs.v[:, 1], np.zeros(7))
+    for a, b in zip(xs.v[0:-1, [0, 2]], xs.v[1:, [0, 2]]):
+        # Each line changes only one coordinate, and is 0.5 long.
+        assert np.sum(a == b) == 1
+        assert np.linalg.norm(a - b) == 0.5
+
+
+def test_intersection_with_mulitple_non_watertight_meshes():
+    xss = intersect_mesh_with_plane(
+        double_box_vertices, double_open_box_faces, Plane.xz
+    )
+
+    assert isinstance(xss, list)
+    assert len(xss) == 2
+
+    first, second = xss
+    assert first.num_v == 7
+    assert second.num_v == 7
+    assert first.is_closed is False
+    assert second.is_closed is False
+
+    # The removed side is not in either xsection.
+    assert not np.any(np.all(first.v == [-0.5, 0.0, 0.0]))
+    assert not np.any(np.all(second.v == [-0.5, 0.0, 0.0]))
+
+    assert first.total_length == 3.0
+    assert second.total_length == 3.0
+
+    np.testing.assert_array_equal(first.v[:, 1], np.zeros(7))
+    np.testing.assert_array_equal(second.v[:, 1], np.zeros(7))
+
+    for xs in xss:
+        for a, b in zip(xs.v[0:-1, [0, 2]], xs.v[1:, [0, 2]]):
+            # Each line changes only one coordinate, and is 0.5 long.
+            assert np.sum(a == b) == 1
+            assert np.linalg.norm(a - b) == 0.5

--- a/hobart/test_validation.py
+++ b/hobart/test_validation.py
@@ -1,0 +1,15 @@
+# Vendored in from lacecore.
+
+import numpy as np
+import pytest
+from ._validation import check_indices
+
+
+def test_check_indices_valid():
+    check_indices(np.repeat(np.arange(8), 3).reshape(-1, 3), 8, "f")
+    check_indices(np.zeros((0, 3)), 8, "f")
+
+
+def test_check_indices_invalid():
+    with pytest.raises(ValueError, match="Expected indices in f to be less than 8"):
+        check_indices(np.arange(24).reshape(-1, 3), 8, "f")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
+polliwog==1.0.0b6
 scipy
 vg>=1.7.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
-polliwog==1.0.0b6
+polliwog==1.0.0b7
 scipy
 vg>=1.7.0,<2.0

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,6 +1,6 @@
 # Imported from code.
 numpy
-polliwog==1.0.0b6
+polliwog==1.0.0b7
 scipy
 vg>=1.7.0,<2.0
 

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,5 +1,6 @@
 # Imported from code.
 numpy
+polliwog==1.0.0b6
 scipy
 vg>=1.7.0,<2.0
 


### PR DESCRIPTION
This is a refactor / rewrite of the mesh–plane intersection code in Lace:

https://github.com/lace/lace/blob/a19d14eeca37a66af442c5a73c3934987d2d7d9a/lace/intersection.py
https://github.com/lace/lace/blob/a19d14eeca37a66af442c5a73c3934987d2d7d9a/lace/test_intersection.py

I've filled in a couple gaps in test coverage, though there are still a few more.

The docs are getting built on Netlify.